### PR TITLE
Change default project name to "sample/hobbit-haven"

### DIFF
--- a/quickstart/dev/index.html
+++ b/quickstart/dev/index.html
@@ -210,7 +210,7 @@ create an app for managing a hobbit settlement:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-sh hljs" data-lang="sh">lein new sweet-tooth-app hobbit-haven # alternatively, "hobbit-hovel" if it's in bad shape
+<pre class="highlightjs highlight"><code class="language-sh hljs" data-lang="sh">lein new sweet-tooth-app sample/hobbit-haven # alternatively, "sample/hobbit-hovel" if it's in bad shape
 cd hobbit-haven</code></pre>
 </div>
 </div>


### PR DESCRIPTION
Clojure project names have to be fully qualified now. 

I happen to use `clojure-deps-edn` so when i used clj-new  via that route, this happened 

``` 
$ clojure -X:project/new :template sweet-tooth-app :name hobbit-haven
Execution error (ExceptionInfo) at clj-new.helpers/create* (helpers.clj:235).
Project names must be valid qualified or multi-segment Clojure symbols.

For example: yourname/hobbit-haven, yourname.hobbit-haven, or hobbit-haven.main
```